### PR TITLE
Add FR_SPELLING_RULE as a rule for unknown words

### DIFF
--- a/ltexls-core/src/main/java/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.java
+++ b/ltexls-core/src/main/java/org/bsplines/ltexls/languagetool/LanguageToolRuleMatch.java
@@ -98,6 +98,7 @@ public class LanguageToolRuleMatch {
         || this.ruleId.startsWith("GERMAN_SPELLER_")
         || this.ruleId.equals("MUZSKY_ROD_NEZIV_A")
         || this.ruleId.equals("ZENSKY_ROD_A")
-        || this.ruleId.equals("STREDNY_ROD_A")));
+        || this.ruleId.equals("STREDNY_ROD_A")
+        || this.ruleId.equals("FR_SPELLING_RULE")));
   }
 }

--- a/ltexls-core/src/test/java/org/bsplines/ltexls/server/DocumentCheckerTest.java
+++ b/ltexls-core/src/test/java/org/bsplines/ltexls/server/DocumentCheckerTest.java
@@ -254,6 +254,15 @@ public class DocumentCheckerTest {
     checkingResult = checkDocument(document, settings);
     Assertions.assertEquals(0, checkingResult.getKey().size());
 
+    document = createDocument("latex", "On trouve des mmots inconnus.\n");
+    settings = (new Settings()).withLanguageShortCode("fr");
+    checkingResult = checkDocument(document, settings);
+    Assertions.assertEquals(1, checkingResult.getKey().size());
+
+    settings = settings.withDictionary(Collections.singleton("mmots"));
+    checkingResult = checkDocument(document, settings);
+    Assertions.assertEquals(0, checkingResult.getKey().size());
+
     document = createDocument("markdown", "This is LT<sub>E</sub>X LS.\n");
     settings = new Settings();
     checkingResult = checkDocument(document, settings);


### PR DESCRIPTION
Hopefully, this should activate the 'add to dictionary' feature.
I wasn't able to test it, though.