### PR TITLE
Add support for \counterwithin, \counterwithout, \numberwithin

### DIFF
--- a/src/main/java/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderDefaults.java
+++ b/src/main/java/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderDefaults.java
@@ -291,6 +291,10 @@ class LatexAnnotatedTextBuilderDefaults {
     list.add(new LatexCommandSignature("\\color[]{}"));
     list.add(new LatexCommandSignature("\\colorbox{}"));
     list.add(new LatexCommandSignature("\\colorlet{}{}"));
+    list.add(new LatexCommandSignature("\\counterwithin{}{}"));
+    list.add(new LatexCommandSignature("\\counterwithin*{}{}"));
+    list.add(new LatexCommandSignature("\\counterwithout{}{}"));
+    list.add(new LatexCommandSignature("\\counterwithout*{}{}"));
     list.add(new LatexCommandSignature("\\cref{}", LatexCommandSignature.Action.DUMMY));
     list.add(new LatexCommandSignature("\\Cref{}", LatexCommandSignature.Action.DUMMY));
     list.add(new LatexCommandSignature("\\crefname{}{}{}"));
@@ -471,6 +475,7 @@ class LatexAnnotatedTextBuilderDefaults {
     list.add(new LatexCommandSignature("\\newtheorem*{}{}"));
     list.add(new LatexCommandSignature("\\newtoggle{}"));
     list.add(new LatexCommandSignature("\\nolinkurl{}", LatexCommandSignature.Action.DUMMY));
+    list.add(new LatexCommandSignature("\\numberwithin{}{}"));
     list.add(new LatexCommandSignature("\\PackageWarning{}{}"));
     list.add(new LatexCommandSignature("\\pagecolor{}"));
     list.add(new LatexCommandSignature("\\pagenumbering{}"));


### PR DESCRIPTION
`\numberwithin` is defined by `amsmath`.

The four other commands are defined by core LaTeX (formerly by the `chngcntr` package).

Information on these commands can be found here:
https://tex.stackexchange.com/questions/28333/continuous-v-per-chapter-section-numbering-of-figures-tables-and-other-docume/28334#28334