### PR TITLE
Add more commands for automatic vowel detection in formulas

### DIFF
--- a/src/main/java/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilder.java
+++ b/src/main/java/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilder.java
@@ -626,9 +626,20 @@ public class LatexAnnotatedTextBuilder extends CodeAnnotatedTextBuilder {
           if (command.equals("\\mathbb") || command.equals("\\mathbf")
                 || command.equals("\\mathcal") || command.equals("\\mathfrak")
                 || command.equals("\\mathit") || command.equals("\\mathnormal")
-                || command.equals("\\mathsf") || command.equals("\\mathtt")) {
+                || command.equals("\\mathsf") || command.equals("\\mathtt")
+                || command.equals("\\mathop") || command.equals("\\operatorname")
+                || command.equals("\\overline") || command.equals("\\underline")
+                || command.equals("\\underbrace") || command.equals("\\overbrace")
+                || command.equals("\\overrightarrow") || command.equals("\\overleftarrow")
+                || command.equals("\\overleftrightarrow") || command.equals("\\vec")
+                || command.equals("\\tilde") || command.equals("\\widetilde")
+                || command.equals("\\hat") || command.equals("\\widehat")
+                || command.equals("\\bm") || command.equals("\\boldsymbol")) {
             // leave this.mathVowelState as MathVowelState.UNDECIDED
-          } else if (command.equals("\\ell")) {
+          } else if (command.equals("\\ell") || command.equals("\\eta")
+                || command.equals("\\epsilon") || command.equals("\\varepsilon")
+                || command.equals("\\omega") || command.equals("\\Omega")
+                || command.equals("\\iota") || command.equals("\\alpha")) {
             this.mathVowelState = MathVowelState.STARTS_WITH_VOWEL;
           } else {
             this.mathVowelState = MathVowelState.STARTS_WITH_CONSONANT;


### PR DESCRIPTION
Related to valentjn/vscode-ltex#131.

## Background
I write papers which constantly uses `an $\alpha$-weighted interpolation` and `an $\widetilde{H}^1$-conforming space`. One day I was too tired at night, fixing typos relying on LTeX (but telling me collaborators I was working hard), and did not manually check the things. The final version almost got to the publication stage...

## Change
Basically added more LaTeX commands in the following block:

https://github.com/valentjn/ltex-ls/blob/287b8e051cd9bda0207523e45dcf5dfece78db1a/src/main/java/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilder.java#L625-L633

- Added some commonly used Greek letters such as `\alpha`, `\epsilon`, etc; 
- Added some commonly used `amsmath` commands such as `\operatorname{}`, `\mathop{}`, and tildes and hats.