### PR TITLE
Add Quarto and RMarkdown support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,10 @@ If you like LT<sub>E</sub>X, but are not able to contribute in any of these ways
 1. Install VS Code, Git, and Apache Maven.
 2. Fork ltex-ls on GitHub.
 3. Clone the fork: `git clone https://github.com/<YOUR_USERNAME>/ltex-ls.git`
-4. Build the project: `cd ltex-ls && mvn verify`
+4. Build the project: 
+   - `cd ltex-ls`
+   - `python -u tools/createCompletionLists.py`
+   - `mvn verify`
 5. It's recommended to use IntelliJ IDEA to debug ltex-ls.
 
 ## How to Contribute Code

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Find more information (how to install, how to use, etc.) at the [website of LT<s
 
 ## Features
 
-- **Supported markup languages:** BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, Git commit messages, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, reStructuredText, R Sweave, XHTML
+- **Supported markup languages:** BibT<sub>E</sub>X, ConT<sub>E</sub>Xt, Git commit messages, L<sup>A</sup>T<sub>E</sub>X, Markdown, Org, R Markdown, reStructuredText, R Sweave, XHTML
 - Comment checking in **many popular programming languages** (optional, opt-in)
 - Comes with **everything included,** no need to install Java or LanguageTool
 - **Offline checking:** Does not upload anything to the internet

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -51,8 +51,9 @@ abstract class CodeAnnotatedTextBuilder(
         "rsweave",
         "tex",
         -> LatexAnnotatedTextBuilder(codeLanguageId)
-        "rmd",
         "markdown",
+        "quarto",
+        "rmd",
         -> MarkdownAnnotatedTextBuilder(codeLanguageId)
         "nop" -> NopAnnotatedTextBuilder(codeLanguageId)
         "org" -> OrgAnnotatedTextBuilder(codeLanguageId)

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeAnnotatedTextBuilder.kt
@@ -51,7 +51,9 @@ abstract class CodeAnnotatedTextBuilder(
         "rsweave",
         "tex",
         -> LatexAnnotatedTextBuilder(codeLanguageId)
-        "markdown" -> MarkdownAnnotatedTextBuilder(codeLanguageId)
+        "rmd",
+        "markdown",
+        -> MarkdownAnnotatedTextBuilder(codeLanguageId)
         "nop" -> NopAnnotatedTextBuilder(codeLanguageId)
         "org" -> OrgAnnotatedTextBuilder(codeLanguageId)
         "plaintext" -> PlaintextAnnotatedTextBuilder(codeLanguageId)

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
@@ -61,7 +61,9 @@ abstract class CodeFragmentizer(
         "rsweave",
         "tex",
         -> LatexFragmentizer(codeLanguageId)
-        "markdown" -> MarkdownFragmentizer(codeLanguageId)
+        "markdown",
+        "rmd",
+        -> MarkdownFragmentizer(codeLanguageId)
         "nop" -> NopFragmentizer(codeLanguageId)
         "org" -> OrgFragmentizer(codeLanguageId)
         "plaintext" -> PlaintextFragmentizer(codeLanguageId)

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
@@ -62,6 +62,7 @@ abstract class CodeFragmentizer(
         "tex",
         -> LatexFragmentizer(codeLanguageId)
         "markdown",
+        "quarto",
         "rmd",
         -> MarkdownFragmentizer(codeLanguageId)
         "nop" -> NopFragmentizer(codeLanguageId)

--- a/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/settings/Settings.kt
@@ -205,6 +205,7 @@ data class Settings(
       "html",
       "markdown",
       "org",
+      "rmd",
       "restructuredtext",
       "rsweave",
     )

--- a/src/main/kotlin/org/bsplines/ltexls/tools/FileIo.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/tools/FileIo.kt
@@ -137,6 +137,9 @@ object FileIo {
       "python"
     } else if (fileName.endsWith(".r")) {
       "r"
+    } else if (fileName.endsWith(".Rmd")
+          || fileName.endsWith(".rmd")) {
+    "rmd"
     } else if (fileName.endsWith(".rst")) {
       "restructuredtext"
     } else if (fileName.endsWith(".Rnw")

--- a/src/main/kotlin/org/bsplines/ltexls/tools/FileIo.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/tools/FileIo.kt
@@ -135,11 +135,13 @@ object FileIo {
       "puppet"
     } else if (fileName.endsWith(".py")) {
       "python"
+    } else if (fileName.endsWith(".qmd")) {
+      "quarto"
     } else if (fileName.endsWith(".r")) {
       "r"
     } else if (fileName.endsWith(".Rmd")
           || fileName.endsWith(".rmd")) {
-    "rmd"
+      "rmd"
     } else if (fileName.endsWith(".rst")) {
       "restructuredtext"
     } else if (fileName.endsWith(".Rnw")

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownFragmentizerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownFragmentizerTest.kt
@@ -107,6 +107,25 @@ class MarkdownFragmentizerTest {
   }
 
   @Test
+  fun testOtherLanguages() {
+    assertFragmentizer(
+      "rmd",
+      """
+      Sentence 1
+
+        <!--       ltex: language=de-DE-->
+
+      Sentence 2
+
+      <!--			ltex:				language=en-US		-->
+
+      Sentence 3
+
+      """.trimIndent(),
+    )
+  }
+
+  @Test
   fun testWrongSettings() {
     val fragmentizer: CodeFragmentizer = CodeFragmentizer.create("markdown")
     fragmentizer.fragmentize(

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownFragmentizerTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/markdown/MarkdownFragmentizerTest.kt
@@ -108,21 +108,21 @@ class MarkdownFragmentizerTest {
 
   @Test
   fun testOtherLanguages() {
-    assertFragmentizer(
-      "rmd",
-      """
-      Sentence 1
+    val markdownSample: String = """
+    Sentence 1
 
-        <!--       ltex: language=de-DE-->
+      <!--       ltex: language=de-DE-->
 
-      Sentence 2
+    Sentence 2
 
-      <!--			ltex:				language=en-US		-->
+    <!--			ltex:				language=en-US		-->
 
-      Sentence 3
+    Sentence 3
 
-      """.trimIndent(),
-    )
+    """.trimIndent()
+
+    assertFragmentizer("rmd", markdownSample)
+    assertFragmentizer("quarto", markdownSample)
   }
 
   @Test


### PR DESCRIPTION
This Pull Request adds Quarto `.qmd` partial support, requested by @JamesM131 in PR #170.

[Pandoc's extensions](https://quarto.org/about.html#project) are not added to the Markdown parser. I wonder whether Quarto's functionality requiring those extensions are really used in practice and whether writing specific rules for `.qmd` is necessary. 

For this reason, I prefer to classify this PR as a Draft since support is partial.