### PR TITLE
Fix German plural of Dummy

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DummyGenerator.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DummyGenerator.kt
@@ -14,6 +14,7 @@ class DummyGenerator private constructor(
   fun generate(language: String, number: Int, vowel: Boolean = false): String {
     return when {
       language.equals("fr", ignoreCase = true) -> "Jimmy-$number"
+      this.plural && language.equals("de", ignoreCase = true) -> "Dummys-$number"
       this.plural -> "Dummies"
       vowel || this.vowel -> "Ina$number"
       else -> "Dummy$number"

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/DummyGenerator.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/DummyGenerator.kt
@@ -14,7 +14,7 @@ class DummyGenerator private constructor(
   fun generate(language: String, number: Int, vowel: Boolean = false): String {
     return when {
       language.equals("fr", ignoreCase = true) -> "Jimmy-$number"
-      this.plural && language.equals("de", ignoreCase = true) -> "Dummys-$number"
+      this.plural && language.startsWith("de", ignoreCase = true) -> "Dummys-$number"
       this.plural -> "Dummies"
       vowel || this.vowel -> "Ina$number"
       else -> "Dummy$number"


### PR DESCRIPTION
In German, the plural form of Dummy is Dumm**y**s, not Dumm**ie**s, which instead triggers a false positive:

![ltex_dummies](https://user-images.githubusercontent.com/571497/181236128-b0d37fc9-4228-434d-8e9d-b287480a5c75.png)

