### PR TITLE
allow pandoc for markdown Fragmentizer

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/CodeFragmentizer.kt
@@ -61,6 +61,7 @@ abstract class CodeFragmentizer(
         "rsweave",
         "tex",
         -> LatexFragmentizer(codeLanguageId)
+        "pandoc",
         "markdown" -> MarkdownFragmentizer(codeLanguageId)
         "nop" -> NopFragmentizer(codeLanguageId)
         "org" -> OrgFragmentizer(codeLanguageId)


### PR DESCRIPTION
Allow `pandoc` as filetype for markdown files.