### PR TITLE
Shorten JSON sent to HTTP server

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolHttpInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolHttpInterface.kt
@@ -107,6 +107,7 @@ class LanguageToolHttpInterface(
     val requestEntries = HashMap<String, String>()
     requestEntries["language"] = this.languageShortCode
     requestEntries["data"] = jsonData.toString()
+    Logging.LOGGER.finer("requestEntries[\"data\"].length = " + requestEntries["data"]!!.length)
 
     if (this.languageToolOrgUsername.isNotEmpty()) {
       requestEntries["username"] = this.languageToolOrgUsername

--- a/src/main/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilder.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilder.kt
@@ -605,6 +605,7 @@ class LatexAnnotatedTextBuilder(
     addMarkup(comment, (if (containsTwoEndsOfLine(comment)) "\n\n" else ""))
   }
 
+  @Suppress("ComplexMethod")
   private fun processWhitespace() {
     val whitespace: String = if ((this.curChar != '~') && (this.curChar != '&')) {
       matchFromPositionAsString(WHITESPACE_REGEX)
@@ -617,6 +618,14 @@ class LatexAnnotatedTextBuilder(
 
     if (isTextMode(this.curMode)) {
       when {
+        // Prefer text to avoid switching between text and markup too often
+        // TODO What about \r\n?
+        this.lastSpace.isEmpty() && (whitespace == " " || whitespace == "\n") -> {
+          addText(" ")
+        }
+        this.lastSpace.isEmpty() && whitespace == "\n\n" -> {
+          addText("\n\n")
+        }
         containsTwoEndsOfLine(whitespace) -> {
           addMarkup(whitespace, "\n\n")
         }

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
@@ -11,6 +11,7 @@ import org.bsplines.ltexls.parsing.AnnotatedTextFragment
 import org.bsplines.ltexls.parsing.CodeAnnotatedTextBuilderTest
 import org.bsplines.ltexls.settings.Settings
 import org.languagetool.markup.AnnotatedText
+import org.languagetool.markup.TextPart
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -517,6 +518,20 @@ class LatexAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("latex") {
       "This is a first sentence.\n\nDummy0 \n\nThis is a second sentence. ",
       "context",
     )
+  }
+
+  @Test
+  fun testMerging() {
+    val annotatedText = buildAnnotatedText(
+      """\hskip\textbf{SomeBoldText}% followed by a comment""",
+    )
+    val parts = annotatedText.getParts()
+    assertEquals(5, parts.size)
+    assertEquals(TextPart.Type.MARKUP, parts[0].type)
+    assertEquals(TextPart.Type.FAKE_CONTENT, parts[1].type)
+    assertEquals(TextPart.Type.TEXT, parts[2].type)
+    assertEquals(TextPart.Type.MARKUP, parts[3].type)
+    assertEquals(TextPart.Type.FAKE_CONTENT, parts[4].type)
   }
 
   private fun assertOriginalTextPositions(

--- a/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
+++ b/src/test/kotlin/org/bsplines/ltexls/parsing/latex/LatexAnnotatedTextBuilderTest.kt
@@ -534,6 +534,16 @@ class LatexAnnotatedTextBuilderTest : CodeAnnotatedTextBuilderTest("latex") {
     assertEquals(TextPart.Type.FAKE_CONTENT, parts[4].type)
   }
 
+  @Test
+  fun testSimpleWhitespace() {
+    val annotatedText = buildAnnotatedText(
+      "This is a test\nOver multiple\n\nLines.",
+    )
+    val parts = annotatedText.getParts()
+    assertEquals(1, parts.size)
+    assertEquals(TextPart.Type.TEXT, parts[0].type)
+  }
+
   private fun assertOriginalTextPositions(
     code: String,
     plainTextStartPos: Int,


### PR DESCRIPTION
This is a first step towards solving https://github.com/valentjn/ltex-ls/issues/215.

The second commit merges consecutive parts of the same type (TEXT and MARKUP) together. This is what gives most savings in the JSON output. I believe merging TEXTs is fine, but I wonder if merging MARKUPs is too aggressive. When you have a match in a long MARKUP part, possibly stretching over multiple lines, then all the lines are "marked". I doubt that this is wrong, but it's certainly a change from the current behavior. @valentjn What do you think?