### PR TITLE
Adding MacOS aarch64 target

### DIFF
--- a/tools/createBinaryArchives.py
+++ b/tools/createBinaryArchives.py
@@ -17,7 +17,7 @@ import urllib.parse
 import urllib.request
 import zipfile
 
-javaVersion = "11.0.12+7"
+javaVersion = "11.0.20.1+1"
 
 
 

--- a/tools/createBinaryArchives.py
+++ b/tools/createBinaryArchives.py
@@ -198,6 +198,7 @@ def getLtexLsVersion() -> str:
 def main() -> None:
   createBinaryArchive("linux", "x64")
   createBinaryArchive("mac", "x64")
+  createBinaryArchive("mac", "aarch64")
   createBinaryArchive("windows", "x64")
 
 


### PR DESCRIPTION
With the rise of Apple Silicon users, we also see a rise in issues like these: https://github.com/valentjn/vscode-ltex/issues/634

This MR aims to resolve the issue of the missing/incorrect MacOS Java installation that ships with ltex-ls.

First, the Java version was updated (still 11.0) to a version where all targets (os + platform) were available.

Secondly, an archive for mac aarch64 will now also be created.

Unfortunately, the build process already failed for me during Kotlin file compilation (guidance appreciated), but the GitHub workflow seems OK at least (although mac aarch64 is not tested, as it does not seem to be available yet for free GitHub workflows - [see here](https://github.blog/2023-10-02-introducing-the-new-apple-silicon-powered-m1-macos-larger-runner-for-github-actions/)).