### PR TITLE
Fix LT HTTP request Content-Type

### DIFF
--- a/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolHttpInterface.kt
+++ b/src/main/kotlin/org/bsplines/ltexls/languagetool/LanguageToolHttpInterface.kt
@@ -66,7 +66,7 @@ class LanguageToolHttpInterface(
 
     val requestBody: String = createRequestBody(annotatedTextFragment) ?: return emptyList()
     val httpRequest: HttpRequest = HttpRequest.newBuilder(this.uri)
-        .header("Content-Type", "application/json")
+        .header("Content-Type", "application/x-www-form-urlencoded")
         .POST(BodyPublishers.ofString(requestBody))
         .build()
     val httpResponse: HttpResponse<String> = try {


### PR DESCRIPTION
The LanguageTool check endpoint actually expects an HTTP request with an "application/x-www-form-urlencoded" Content-Type. Currently ltex-ls uses the "application/json" Content-Type for the HTTP request, but this does not play well with some third-party tools that follow the same LanguageTool API like https://github.com/cpg314/ltapiserv-rs.

The official LanguageTool HTTP server does not seem to be affected by this bug.

See the API documentation: https://languagetool.org/http-api/swagger-ui/#!/default/post_check